### PR TITLE
docs: 更新安装示例至 v0.3.0

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -60,9 +60,9 @@ make install
 
 举个例子
 ```
-curl -OL https://github.com/ucloud/ucloud-cli/releases/download/0.1.23/ucloud-cli-linux-0.1.23-amd64.tgz
-echo "b480f8621e8d0bd2c121221857029320eb49be708f4d7cb1b197cdc58b071c09 *ucloud-cli-linux-0.1.23-amd64.tgz" | shasum -c //检查下载的tar包是否被劫持，从发布页面获取sha256摘要
-tar zxf ucloud-cli-linux-0.1.23-amd64.tgz -C /usr/local/bin/
+curl -OL https://github.com/ucloud/ucloud-cli/releases/download/v0.3.0/ucloud-linux_amd64.zip
+echo "24e60516a0b4642ab58c66e9bd073313f51e277d9033a08027490323e37b9ada *ucloud-linux_amd64.zip" | shasum -c //检查下载的压缩包是否被劫持，从发布页面获取sha256摘要
+unzip ucloud-linux_amd64.zip -d /tmp/ucloud-cli && sudo mv /tmp/ucloud-cli/bin/ucloud /usr/local/bin/
 ```
 
 ## 在Windows平台上安装UCloud-CLI


### PR DESCRIPTION
## 背景

`intro.md` 中"举个例子"的下载示例基于 **0.1.23**（2019 年前后），该 tag 资源包已不再维护，`.tgz` 命名与当前发布不兼容，读者按原文执行会在 `curl` 或 `shasum -c` 阶段失败。

## 变更

**仅改动"举个例子"代码块内 3 行命令**，升级到 v0.3.0（2024-09-20 发布，当前最新稳定版）：

| 项 | 旧 | 新 |
|---|---|---|
| URL | `0.1.23/ucloud-cli-linux-0.1.23-amd64.tgz` | `v0.3.0/ucloud-linux_amd64.zip` |
| sha256 | `b480f8...c09` | `24e60516a0b4642ab58c66e9bd073313f51e277d9033a08027490323e37b9ada` |
| 解压 | `tar zxf ... -C /usr/local/bin/` | `unzip ... -d /tmp/ucloud-cli && sudo mv .../bin/ucloud /usr/local/bin/` |

文档其他段落分毫未改。

## 验证

- `curl -OL` 下载 HTTP 200
- `shasum -a 256 -c` 校验通过
- `unzip` 解压产物 `bin/ucloud` 具可执行权限
- 本地运行 `./bin/ucloud --version` 输出 `ucloud cli 0.3.0`